### PR TITLE
derives lens traits for structx

### DIFF
--- a/lens-rs/Cargo.toml
+++ b/lens-rs/Cargo.toml
@@ -14,4 +14,4 @@ description = "lens implemented in rust"
 inwelling = "0.3"
 
 [dependencies]
-lens-rs_derive = "0.2"
+lens-rs_derive = { path = "../lens-rs_derive", version = "0.2" }


### PR DESCRIPTION
    1. Specify path for the dependency of lens-rs_derive in lens-rs's Cargo.toml.
      According to the [cargo book](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html?highlight=specify%20depend#multiple-locations):
      > One example where this can be useful is when you have split up a library into multiple packages within the same workspace. You can then use path dependencies to point to the local packages within the workspace to use the local version during development, and then use the crates.io version once it is published.
    
    2. Crate lens-rs_derive adds experimental support for deriving lens_rs::{Optic, Review, Prism, Lens} for [structx](https://github.com/oooutlk/structx/tree/structx_derives_lens).